### PR TITLE
add attribute superAdmin in user model

### DIFF
--- a/src/db/migrations/20231220030157-modify_user_add_attribute_superAdmin.ts
+++ b/src/db/migrations/20231220030157-modify_user_add_attribute_superAdmin.ts
@@ -1,0 +1,18 @@
+'use strict';
+
+
+/** @type {import('sequelize').Sequelize} */
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await Promise.all([
+      queryInterface.addColumn('user', 'superAdmin', {
+        allowNull: false,
+        type: Sequelize.BOOLEAN,
+      }),
+    ]);
+  },
+  down: async queryInterface => {
+    await queryInterface.dropTable('user');
+  },
+};

--- a/src/db/models/user.ts
+++ b/src/db/models/user.ts
@@ -7,6 +7,7 @@ export interface UserAttributes {
   lastName: string;
   email: string;
   password: string;
+  superAdmin: boolean;
   active: boolean;
 }
 
@@ -45,6 +46,11 @@ export const User = sequelize.define<UserInstance>(
     password: {
       allowNull: true,
       type: DataTypes.TEXT,
+    },
+    superAdmin: {
+      allowNull: false,
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
     },
     active: {
       allowNull: false,


### PR DESCRIPTION
no use :

import { DataTypes, QueryInterface } from 'sequelize';

por que no me toma el import al querer ejecutar las migraciones.   Problemas con las importaciones de ES6 en un contexto de CommonJS.